### PR TITLE
nullish checking

### DIFF
--- a/src/getCallee.ts
+++ b/src/getCallee.ts
@@ -4,13 +4,15 @@ export function getCallee(): Callee {
   try {
     throw new Error()
   } catch (e) {
-    const line = e.stack.split('\n')[3] || ''
+    const error = e as Error;
+
+    const line = error.stack?.split('\n')[3] ?? ''
     const functionNameMatch = line.match(/\w+@|at (([^(]+)) \(.*/)
     const functionName = (functionNameMatch && functionNameMatch[1]) || ''
 
     const result = line.match(/(\/[^:]+):([0-9]+):[0-9]+/)
-    const filePath = result[1] || ''
-    const lineNumber = result[2] || ''
+    const filePath = result?.[1] ?? ''
+    const lineNumber = result?.[2] ?? ''
 
     return {
       functionName,


### PR DESCRIPTION
If `result` is nullish, it will throw an error due to incorrect nullish checking.
I fixed nullish checking by using optional chaining and the nullish coalescing operator (not needed, but is stricter for TS).